### PR TITLE
SCL-2

### DIFF
--- a/src/main/scala/scalacl/impl/CLFunctionMacros.scala
+++ b/src/main/scala/scalacl/impl/CLFunctionMacros.scala
@@ -96,7 +96,7 @@ object CLFunctionMacros {
         List(
           ValDef(
             NoMods,
-            c.fresh("noarg"): TermName,
+            c.freshName(TermName("noarg")),
             TypeTree(UnitTpe),
             EmptyTree)
         ),

--- a/src/main/scala/scalacl/impl/CLFunctionUtils.scala
+++ b/src/main/scala/scalacl/impl/CLFunctionUtils.scala
@@ -53,9 +53,9 @@ object CLFunctionUtils {
       case t if t.symbol != null && ri.isFreeTerm(t.symbol) =>
         ri.asFreeTerm(t.symbol)
     }
-    ast = simplifyGenericTree(toolbox.typeCheck(ast, f.value.valueTag.tpe))
+    ast = simplifyGenericTree(toolbox.typecheck(tree = ast, pt = f.value.valueTag.tpe))
     // println("SIMPLIFIED AST: " + ast)
-    ast = toolbox.resetLocalAttrs(ast)
+    ast = toolbox.untypecheck(ast)
     //ast = toolbox.typeCheck(ast, f.value.valueTag.tpe)
 
     type Result = ru.Tree
@@ -75,7 +75,7 @@ object CLFunctionUtils {
       val freshName = getFreshNameGenerator(ast)
       def fresh(s: String) = freshName(s).toString
 
-      val outputSymbol = internal.newTermSymbol(NoSymbol, fresh("out"))
+      val outputSymbol = internal.newTermSymbol(NoSymbol, TermName(fresh("out")))
 
       val result = functionToFunctionKernel(
         captureFunction = castTree(ff),

--- a/src/main/scala/scalacl/impl/KernelMacros.scala
+++ b/src/main/scala/scalacl/impl/KernelMacros.scala
@@ -45,7 +45,7 @@ object KernelMacros {
       val result =
         vectorize(
           contextExpr.asInstanceOf[global.Expr[scalacl.Context]],
-          c.typeCheck(block.tree).asInstanceOf[global.Tree]
+          c.typecheck(block.tree).asInstanceOf[global.Tree]
         )
     }
     val result = vectorizer.result.asInstanceOf[Option[c.Expr[Unit]]]

--- a/src/main/scala/scalacl/impl/package.scala
+++ b/src/main/scala/scalacl/impl/package.scala
@@ -6,7 +6,7 @@ package object impl {
   def typeCheckOrTrace[A](c: blackbox.Context)(msg: => String)(block: => c.Expr[A]): c.Expr[A] = {
     import c.universe._
     tryOrTrace(msg) {
-      c.Expr[A](c.typeCheck(block.tree))
+      c.Expr[A](c.typecheck(block.tree))
     }
   }
   def tryOrTrace[A](msg: => String)(block: => A): A = {


### PR DESCRIPTION
## Fixup 
- fix some warnings for Scala 2.11
## QA

There is still some warnings
- Not a simple type -> https://issues.scala-lang.org/browse/SI-7701

``` scala
[warn] Transformed: class xsbti.api.Structure
[warn] Not a simple type:
```
